### PR TITLE
Add "rimmen" to word list and approved words

### DIFF
--- a/data/gekeurd.txt
+++ b/data/gekeurd.txt
@@ -94565,6 +94565,7 @@ rillettes
 rillijn
 rilling
 rimboe
+rimmen
 rimpel
 rimpelen
 rimpelig

--- a/data/woorden.json
+++ b/data/woorden.json
@@ -30603,7 +30603,8 @@
         "peerse",
         "ceylon",
         "kaylee",
-        "witzen"
+        "witzen",
+        "rimmen"
     ],
     "7": [
         "hofstee",


### PR DESCRIPTION
This PR adds the word "rimmen" to the application's word lists.

## Summary
Added the Dutch word "rimmen" to both the word database and the approved words list.

## Changes
- Added "rimmen" to the 6-letter words list in `data/woorden.json`
- Added "rimmen" to the approved words list in `data/gekeurd.txt` (in alphabetical order between "rimboe" and "rimpel")

## Details
The word has been properly integrated into both data files, maintaining alphabetical ordering in the approved words list.

https://claude.ai/code/session_01Qfc83QP6kBZXH22Rct6sPF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new word entry to the system's word database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->